### PR TITLE
Add Version command

### DIFF
--- a/lib/ruby_fly.rb
+++ b/lib/ruby_fly.rb
@@ -27,6 +27,10 @@ module RubyFly
     def unpause_pipeline(opts = {})
       Commands::UnpausePipeline.new.execute(opts)
     end
+
+    def version
+      Commands::Version.new.execute()
+    end
   end
   extend ClassMethods
 

--- a/lib/ruby_fly/commands.rb
+++ b/lib/ruby_fly/commands.rb
@@ -1,6 +1,7 @@
 require_relative 'commands/get_pipeline'
 require_relative 'commands/set_pipeline'
 require_relative 'commands/unpause_pipeline'
+require_relative 'commands/version'
 
 module RubyFly
   module Commands

--- a/lib/ruby_fly/commands/version.rb
+++ b/lib/ruby_fly/commands/version.rb
@@ -1,0 +1,24 @@
+require 'lino'
+require_relative 'base'
+
+module RubyFly
+  module Commands
+    class Version < Base
+      def stdout
+        @version_string
+      end
+
+      def do_before(opts)
+        @version_string = StringIO.new
+      end
+
+      def configure_command(builder, opts)
+        builder.with_flag('--version')
+      end
+
+      def do_after(opts)
+        @version_string.string.gsub(/\n/, '')
+      end
+    end
+  end
+end

--- a/spec/commands/version_spec.rb
+++ b/spec/commands/version_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe RubyFly::Commands::Version do
+  it 'calls the fly command passing the version flag' do
+    command = RubyFly::Commands::Version.new(binary: 'fly')
+
+    expect(Open4).to(
+        receive(:spawn)
+            .with('fly --version', any_args))
+
+    command.execute()
+  end
+end


### PR DESCRIPTION
This gets the version of Fly using `fly --version`, meaning we can use it instead of bleeding knowledge of Lino when we ensure `fly` is available.

Had to mess around a bit, exploiting the fact `do_after` is the return value of the execute function. Not sure if this is how it should be done.

Happy to change it.
